### PR TITLE
t/46: Made the .ck-editor always relatively positioned.

### DIFF
--- a/theme/components/editor.scss
+++ b/theme/components/editor.scss
@@ -5,6 +5,11 @@
 @include ck-editor {
 	@include ck-rounded-corners();
 
+	// All the elements within `.ck-editor` are positioned relatively to it.
+	// If any element needs to be positioned with respect to the <body>, etc.,
+	// it must land outside of the `.ck-editor` in DOM.
+	position: relative;
+
 	.ck-editor__top {
 		.ck-toolbar {
 			border-top: 0;


### PR DESCRIPTION
Closes #46.