### PR TITLE
t/52 Fixed: ck-dropshadow() looks bad on dark backgrounds.

### DIFF
--- a/theme/helpers/_colors.scss
+++ b/theme/helpers/_colors.scss
@@ -25,6 +25,7 @@ $_ck-colors: (
 	'focus': #83BFFC,
 	'foreground': #f7f7f7,
 	'text': #333,
+	'shadow': rgba(0,0,0,.2)
 );
 
 /**

--- a/theme/helpers/_shadow.scss
+++ b/theme/helpers/_shadow.scss
@@ -2,5 +2,5 @@
 // For licensing, see LICENSE.md or http://ckeditor.com/license
 
 @mixin ck-dropshadow() {
-	box-shadow: 0 0 5px ck-color( 'foreground', -15 );
+	box-shadow: 0 0 5px ck-color( 'shadow' );
 }


### PR DESCRIPTION
Fixes #52.