### PR TITLE
t/76: Fixed toolbar separator and new line CSS classes incompatible with naming guidelines

### DIFF
--- a/tests/manual/theme.js
+++ b/tests/manual/theme.js
@@ -16,6 +16,7 @@ import IconView from '@ckeditor/ckeditor5-ui/src/icon/iconview';
 import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
 import createListDropdown from '@ckeditor/ckeditor5-ui/src/dropdown/list/createlistdropdown';
 import ToolbarView from '@ckeditor/ckeditor5-ui/src/toolbar/toolbarview';
+import ToolbarSeparatorView from '@ckeditor/ckeditor5-ui/src/toolbar/toolbarseparatorview';
 
 import boldIcon from '@ckeditor/ckeditor5-basic-styles/theme/icons/bold.svg';
 import italicIcon from '@ckeditor/ckeditor5-basic-styles/theme/icons/italic.svg';
@@ -334,19 +335,6 @@ function dropdown( {
 	return dropdown;
 }
 
-const ToolbarSeparatorView = class extends View {
-	constructor() {
-		super();
-
-		this.template = new Template( {
-			tag: 'span',
-			attributes: {
-				class: 'ck-toolbar-separator'
-			}
-		} );
-	}
-};
-
 function toolbarSeparator() {
 	return new ToolbarSeparatorView();
 }
@@ -358,7 +346,7 @@ const ToolbarNewlineView = class extends View {
 		this.template = new Template( {
 			tag: 'span',
 			attributes: {
-				class: 'ck-toolbar-newline'
+				class: 'ck-toolbar__newline'
 			}
 		} );
 	}

--- a/theme/components/toolbar.scss
+++ b/theme/components/toolbar.scss
@@ -10,14 +10,14 @@
 	@include ck-unselectable();
 	@include ck-rounded-corners();
 
-	&-separator {
+	&__separator {
 		width: 1px;
 		height: calc( 1em + 2 * #{ck-spacing( 'medium' )} );
 		vertical-align: middle;
 		background: ck-border-color();
 	}
 
-	&-newline {
+	&__newline {
 		height: ck-spacing( 'small' );
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Toolbar separator and new line CSS classes incompatible with naming guidelines. Also used `ToolbarSeparatorView` in the manual test. Closes #76.

---

### Additional information

* Requires https://github.com/ckeditor/ckeditor5-ui/pull/160.
