### PR TITLE
T/82: Removed tick symbol from active list item, used inverted background and text colors instead

### DIFF
--- a/theme/components/list.scss
+++ b/theme/components/list.scss
@@ -2,14 +2,15 @@
 // For licensing, see LICENSE.md or http://ckeditor.com/license
 
 .ck-list {
+	@include ck-rounded-corners();
+	@include ck-unselectable();
+
 	list-style-type: none;
 	background: ck-color( 'background' );
 
-	@include ck-rounded-corners();
-
 	&__item {
 		padding: ck-spacing( 'medium' );
-		cursor: pointer;
+		cursor: default;
 		min-width: 12em;
 
 		&:hover,

--- a/theme/components/list.scss
+++ b/theme/components/list.scss
@@ -8,21 +8,9 @@
 	@include ck-rounded-corners();
 
 	&__item {
-		padding: ck-spacing( 'medium' ) ck-spacing( 'medium' ) ck-spacing( 'medium' ) 0;
+		padding: ck-spacing( 'medium' );
 		cursor: pointer;
 		min-width: 12em;
-
-		// NOTE: Using absolute sizes here because otherwise each
-		// item would indent in a different way.
-		&::before {
-			content: "";
-			display: inline-block;
-			width: $ck-font-size-base;
-			font-weight: normal;
-			font-size: $ck-font-size-base;
-			text-align: center;
-			margin: 0 $ck-font-size-base/2;
-		}
 
 		&:hover,
 		&:focus {
@@ -41,15 +29,12 @@
 		}
 
 		&_active {
-			background: ck-color( 'foreground', -5 );
-
-			&::before {
-				content: "✓";
-			}
+			background: ck-color( 'active' );
+			color: ck-color( 'background' );
 
 			&:hover,
 			&:focus {
-				background: ck-color( 'foreground', -10 );
+				background: ck-color( 'active', -10 );
 			}
 		}
 	}

--- a/theme/helpers/_colors.scss
+++ b/theme/helpers/_colors.scss
@@ -23,6 +23,7 @@ $_ck-colors: (
 	'focus': #6ab5f9,
 	'foreground': #f7f7f7,
 	'text': #333,
+	'active': #1A8BF1,
 	'shadow': rgba(0,0,0,.2)
 );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Removed tick symbol from active list item, used inverted background and text colors instead. Closes #82.

---

### Additional information

![image](https://cloud.githubusercontent.com/assets/1099479/23946656/886e9650-097b-11e7-98f1-828bae0056ab.png)

Closes https://github.com/ckeditor/ckeditor5-heading/issues/65.