### PR TITLE
t/89:  Implemented `.ck-editor-toolbar-container` class to control balloon panels containing editor toolbars

### DIFF
--- a/theme/components/editor.scss
+++ b/theme/components/editor.scss
@@ -31,3 +31,20 @@
 	}
 }
 
+.ck-editor-toolbar-container.ck-balloon-panel_arrow {
+	&_n,
+	&_ne,
+	&_nw {
+		&:after {
+			border-bottom-color: ck-color( 'foreground' );
+		}
+	}
+
+	&_s,
+	&_se,
+	&_sw {
+		&:after {
+			border-top-color: ck-color( 'foreground' );
+		}
+	}
+}

--- a/theme/components/panel/balloonpanel.scss
+++ b/theme/components/panel/balloonpanel.scss
@@ -111,22 +111,4 @@ $ck-balloon-arrow-half-width: 10px;
 			}
 		}
 	}
-
-	&.ck-toolbar-container {
-		&_arrow_n,
-		&_arrow_ne,
-		&_arrow_nw {
-			&:after {
-				border-bottom-color: ck-color( 'foreground' );
-			}
-		}
-
-		&_arrow_s,
-		&_arrow_se,
-		&_arrow_sw {
-			&:after {
-				border-top-color: ck-color( 'foreground' );
-			}
-		}
-	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Implemented `.ck-editor-toolbar-container` class to control balloon panels containing editor toolbars. Closes #89.
