### PR TITLE
t/69: Balloon panel content should not be misaligned when it's narrow

### DIFF
--- a/theme/components/panel/balloonpanel.scss
+++ b/theme/components/panel/balloonpanel.scss
@@ -9,7 +9,6 @@ $ck-balloon-arrow-half-width: 10px;
 	@include ck-rounded-corners();
 	@include ck-drop-shadow();
 
-	min-width: 50px;
 	min-height: 15px;
 
 	background: ck-color( 'background' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fixed: Balloon panel content should not be misaligned when it's narrow. Closes #69.
