### PR TITLE
t/70: Tooltips for disabled buttons should not be dimmed

### DIFF
--- a/theme/components/button.scss
+++ b/theme/components/button.scss
@@ -66,6 +66,13 @@ a.ck-button {
 		float: left;
 	}
 
+	// https://github.com/ckeditor/ckeditor5-theme-lark/issues/70
+	&.ck-disabled {
+		@include ck-button-icon {
+			@include ck-disabled;
+		}
+	}
+
 	&.ck-button_with-text {
 		padding: ck-spacing( 'small' ) ck-spacing();
 

--- a/theme/components/dropdown.scss
+++ b/theme/components/dropdown.scss
@@ -14,6 +14,15 @@
 		// A space to accommodate the triangle.
 		padding-right: 2 * ck-spacing();
 
+		// https://github.com/ckeditor/ckeditor5-theme-lark/issues/70
+		&.ck-disabled {
+			@include ck-button-colors( 'background', 10 );
+
+			.ck-button__label {
+				@include ck-disabled;
+			}
+		}
+
 		// #23
 		.ck-button__label {
 			width: 7em;

--- a/theme/helpers/_states.scss
+++ b/theme/helpers/_states.scss
@@ -12,10 +12,15 @@ $ck-focus-outer-shadow: 0 0 3px 2px lighten( ck-color( 'focus' ), 10% );
 $ck-focus-ring: 1px solid ck-color( 'focus' );
 
 /**
+ * An opacity value of disabled UI item
+ */
+$ck-disabled-opacity: .5;
+
+/**
  * A class which indicates that an element holding it is disabled.
  */
-.ck-disabled {
-	opacity: .5;
+@mixin ck-disabled {
+	opacity: $ck-disabled-opacity;
 }
 
 /**

--- a/theme/helpers/_states.scss
+++ b/theme/helpers/_states.scss
@@ -12,7 +12,7 @@ $ck-focus-outer-shadow: 0 0 3px 2px lighten( ck-color( 'focus' ), 10% );
 $ck-focus-ring: 1px solid ck-color( 'focus' );
 
 /**
- * An opacity value of disabled UI item
+ * An opacity value of disabled UI item.
  */
 $ck-disabled-opacity: .5;
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Tooltips for disabled buttons should not be dimmed. Closes #70.

BREAKING CHANGE: `.ck-disabled` is no longer available as a standalone class due to differences in the implementation of the disabled state among the UI components. Use a mixin instead `.your-class.ck-disabled { @include ck-disabled; }` to keep the previous functionality (reduced `opacity`) or provide a custom implementation of the state.