### PR TITLE
t/93: Toolbar items should not collapse when the toolbar is floating

### DIFF
--- a/theme/components/toolbar/toolbar.scss
+++ b/theme/components/toolbar/toolbar.scss
@@ -5,7 +5,16 @@
 	line-height: 1;
 	padding: ck-spacing( 'small' );
 	border: 1px solid ck-border-color();
+
+	// Allow wrapping toolbar items to the new line.
 	white-space: initial;
+
+	&_floating {
+		// Disallow wrapping toolbar items to the new line when the toolbar is floating,
+		// resulting in an toolbar shapes when the horizontal space is limited.
+		// https://github.com/ckeditor/ckeditor5-theme-lark/issues/93
+		white-space: nowrap;
+	}
 
 	@include ck-unselectable();
 	@include ck-rounded-corners();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Toolbar items should not collapse when the toolbar is floating. Closes #93.