### PR TITLE
Other: The .ck-balloon-panel_arrow styles need update after recent BalloonPanelView refactoring

### DIFF
--- a/theme/components/panel/balloonpanel.scss
+++ b/theme/components/panel/balloonpanel.scss
@@ -69,7 +69,7 @@ $ck-balloon-arrow-half-width: 10px;
 			}
 		}
 
-		&_ne {
+		&_nw {
 			&:before,
 			&:after {
 				left: 2 * $ck-balloon-arrow-half-width;
@@ -77,7 +77,7 @@ $ck-balloon-arrow-half-width: 10px;
 			}
 		}
 
-		&_nw {
+		&_ne {
 			&:before,
 			&:after {
 				right: 2 * $ck-balloon-arrow-half-width;
@@ -94,7 +94,7 @@ $ck-balloon-arrow-half-width: 10px;
 			}
 		}
 
-		&_se {
+		&_sw {
 			&:before,
 			&:after {
 				left: 2 * $ck-balloon-arrow-half-width;
@@ -102,7 +102,7 @@ $ck-balloon-arrow-half-width: 10px;
 			}
 		}
 
-		&_sw {
+		&_se {
 			&:before,
 			&:after {
 				right: 2 * $ck-balloon-arrow-half-width;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: The `.ck-balloon-panel` arrow styles need an update after recent `BalloonPanelView` refactoring. Closes #95.

BREAKING CHANGE: The (`.ck-balloon-panel_arrow_nw`–`.ck-balloon-panel_arrow_ne`) and (`.ck-balloon-panel_arrow_sw`–`.ck-balloon-panel_arrow_se`) class pairs have been swapped to reflect the actual placement of the arrow with respect to the balloon.