### PR TITLE
t/105: The .ck-reset class should set word-wrap to break-word to make sure long words do not overflow

### DIFF
--- a/theme/components/reset.scss
+++ b/theme/components/reset.scss
@@ -13,6 +13,9 @@
 	text-decoration: none;
 	vertical-align: middle;
 	transition: none;
+
+	// https://github.com/ckeditor/ckeditor5-theme-lark/issues/105
+	word-wrap: break-word;
 }
 
 /**


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The `.ck-reset` class should set `word-wrap` to `break-word` to make sure long words do not overflow. Closes #105.

---

### Additional information

* Also closes https://github.com/ckeditor/ckeditor5/issues/462.
