### PR TITLE
t/111: Contextual toolbar container's arrow should have the same color as the toolbar

### DIFF
--- a/theme/components/editor.scss
+++ b/theme/components/editor.scss
@@ -46,7 +46,8 @@
 	}
 }
 
-.ck-editor-toolbar-container.ck-balloon-panel_arrow {
+// https://github.com/ckeditor/ckeditor5-theme-lark/issues/111
+.ck-toolbar-container.ck-editor-toolbar-container.ck-balloon-panel_arrow {
 	&_n,
 	&_ne,
 	&_nw {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Contextual toolbar container's arrow should have the same color as the toolbar. Closes #111.
