### PR TITLE
t/116: First child of editable should always have top margin

### DIFF
--- a/theme/ckeditor5-ui/components/editorui/editorui.css
+++ b/theme/ckeditor5-ui/components/editorui/editorui.css
@@ -22,6 +22,11 @@
 	overflow: auto;
 	padding: 0 var(--ck-spacing-standard);
 	border: 1px solid transparent;
+
+	/* https://github.com/ckeditor/ckeditor5-theme-lark/issues/116 */
+	& > *:first-child {
+		margin-top: var(--ck-spacing-standard);
+	}
 }
 
 .ck-editor-toolbar {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: First child of editable should always have a top margin to make sure the content is separated. Closes #116. Closes ckeditor/ckeditor5-ui#351.
