### PR TITLE
Fix: SplitButton state `isOn` is not properly shown.

### DIFF
--- a/theme/ckeditor5-ui/components/editorui/editorui.css
+++ b/theme/ckeditor5-ui/components/editorui/editorui.css
@@ -36,8 +36,10 @@
 	}
 
 	/* https://github.com/ckeditor/ckeditor5-theme-lark/issues/120 */
+	/* https://github.com/ckeditor/ckeditor5-theme-lark/issues/131 */
 	& > .ck-button,
-	& > * > .ck-button {
+	& > .ck-dropdown > .ck-button,
+	& > .ck-dropdown > .ck-splitbutton > .ck-button {
 		&:not(:hover):not(:focus):not(.ck-on),
 		&.ck-disabled {
 			background: transparent;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: SplitButton state `isOn` is not properly shown. Closes #131.
