### PR TITLE
t/ckeditor5/805: Replaced the gradient with a solid color in the editor toolbar

### DIFF
--- a/theme/ckeditor5-ui/globals/_colors.css
+++ b/theme/ckeditor5-ui/globals/_colors.css
@@ -4,9 +4,9 @@
  */
 
 :root {
-	--ck-color-base-foreground: 								hsl(0, 0%, 97%);
+	--ck-color-base-foreground: 								hsl(0, 0%, 98%);
 	--ck-color-base-background: 								hsl(0, 0%, 100%);
-	--ck-color-base-border: 									hsl(0, 0%, 72%);
+	--ck-color-base-border: 									hsl(0, 0%, 77%);
 	--ck-color-base-action: 									hsl(104, 44%, 48%);
 	--ck-color-base-focus: 										hsl(209, 92%, 70%);
 	--ck-color-base-text: 										hsl(0, 0%, 20%);
@@ -96,7 +96,7 @@
 	/* -- Editor -------------------------------------------------------------------------------- */
 
 	--ck-color-editor-border: 									var(--ck-color-base-border);
-	--ck-color-editor-toolbar-background: 						linear-gradient(0, var(--ck-color-base-foreground), var(--ck-color-base-background));
+	--ck-color-editor-toolbar-background: 						var(--ck-color-base-foreground);
 
 	--ck-color-editor-toolbar-button-on-background: 			hsl(0, 0%, 87%);
 	--ck-color-editor-toolbar-button-on-border: 				transparent;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Replaced the gradient with a solid color in the editor toolbar. Closes ckeditor/ckeditor5#805.

----

## Before

![localhost_cke5___build_docs_ckeditor5_1 0 0-alpha 2_examples_builds_classic-editor html](https://user-images.githubusercontent.com/1099479/36211658-24433052-11a2-11e8-8992-42902947b4ae.png)

## After

![localhost_cke5___build_docs_ckeditor5_1 0 0-alpha 2_examples_builds_classic-editor html 1](https://user-images.githubusercontent.com/1099479/36211654-2102a968-11a2-11e8-9078-aafbb293c288.png)
