### PR TITLE
t/ckeditor5/815: The input focus outline should not overwhelm the surrounding form

### DIFF
--- a/theme/ckeditor5-ui/components/inputtext/inputtext.css
+++ b/theme/ckeditor5-ui/components/inputtext/inputtext.css
@@ -23,6 +23,9 @@
 	/* This is important to stay of the same height as surrounding buttons */
 	min-height: var(--ck-ui-component-min-height);
 
+	transition-property: box-shadow, border;
+	transition: .2s ease-in-out;
+
 	&:focus {
 		@mixin ck-focus-ring;
 		@mixin ck-box-shadow var(--ck-focus-outer-shadow), var(--ck-inner-shadow);

--- a/theme/ckeditor5-ui/components/inputtext/inputtext.css
+++ b/theme/ckeditor5-ui/components/inputtext/inputtext.css
@@ -23,7 +23,7 @@
 	/* This is important to stay of the same height as surrounding buttons */
 	min-height: var(--ck-ui-component-min-height);
 
-	transition-property: box-shadow, border;
+	transition-property: box-shadow,border;
 	transition: .2s ease-in-out;
 
 	&:focus {

--- a/theme/ckeditor5-ui/globals/_focus.css
+++ b/theme/ckeditor5-ui/globals/_focus.css
@@ -7,7 +7,7 @@
 	/**
 	 * A visual style of focused element's outer shadow.
 	 */
-	--ck-focus-outer-shadow: 0 0 3px 1px var(--ck-color-focus-shadow);
+	--ck-focus-outer-shadow: 0 0 3px var(--ck-color-focus-shadow);
 
 	/**
 	 * A visual style of focused element's border or outline.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The input focus outline should not overwhelm the surrounding form. Closes ckeditor/ckeditor5#815.

---

### Additional information

## Before

![localhost_8125_ckeditor5-core_tests_manual_article html 8](https://user-images.githubusercontent.com/1099479/36264752-e7fe0c4e-126d-11e8-8a11-d3c564b63746.png)


## After

![localhost_8125_ckeditor5-core_tests_manual_article html 7](https://user-images.githubusercontent.com/1099479/36264761-eb21be98-126d-11e8-80c1-bfc78da226e4.png)
