### PR TITLE
t/ckeditor5/847: A lone paragraph should be vertically centered in the editor

### DIFF
--- a/theme/ckeditor5-ui/components/editorui/editorui.css
+++ b/theme/ckeditor5-ui/components/editorui/editorui.css
@@ -25,7 +25,12 @@
 
 	/* https://github.com/ckeditor/ckeditor5-theme-lark/issues/116 */
 	& > *:first-child {
-		margin-top: var(--ck-spacing-standard);
+		margin-top: var(--ck-spacing-large);
+	}
+
+	/* https://github.com/ckeditor/ckeditor5/issues/847 */
+	& > *:last-child {
+		margin-bottom: var(--ck-spacing-large);
 	}
 }
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: A lone paragraph should be vertically centered in the editor. Closes ckeditor/ckeditor5#847.

---

### Additional information

Also increased the top and bottom margins to make them slightly bigger than left/right editable padding

![image](https://user-images.githubusercontent.com/1099479/36303936-28966b20-130e-11e8-86c1-01c41eae7069.png)
