### PR TITLE
t/ckeditor5/816: Fixed border-radius of active dropdown button & panel.

### DIFF
--- a/theme/ckeditor5-ui/components/dropdown/dropdown.css
+++ b/theme/ckeditor5-ui/components/dropdown/dropdown.css
@@ -3,72 +3,71 @@
  * For licensing, see LICENSE.md.
  */
 
- @import "../../../mixins/_rounded.css";
- @import "../../../mixins/_disabled.css";
- @import "../../../mixins/_shadow.css";
- 
- :root {
-	 --ck-dropdown-arrow-size: calc(0.5 * var(--ck-icon-size));
- }
- 
- .ck-dropdown {
-	 /* Enable font size inheritance, which allows fluid UI scaling. */
-	 font-size: inherit;
- 
-	 & .ck-dropdown__arrow {
-		 right: var(--ck-spacing-standard);
-		 width: var(--ck-dropdown-arrow-size);
-	 }
- 
-	 &.ck-disabled .ck-dropdown__arrow {
-		 @mixin ck-disabled;
-	 }
- 
-	 & .ck-button.ck-dropdown__button {
-		 /* A space to accommodate the triangle. */
-		 padding-right: calc(2.5 * var(--ck-spacing-standard));
- 
-		 &:not(.ck-button_with-text) {
-			 /* Make sure dropdowns with just an icon have the right inner spacing */
-			 padding-left: var(--ck-spacing-small);
-		 }
- 
-		 /* https://github.com/ckeditor/ckeditor5-theme-lark/issues/70 */
-		 &.ck-disabled .ck-button__label {
-			 @mixin ck-disabled;
-		 }
- 
-		 &.ck-on {
-			 border-bottom-left-radius: 0;
-			 border-bottom-right-radius: 0;
-		 }
- 
-		 /* #23 */
-		 & .ck-button__label {
-			 width: 7em;
-			 overflow: hidden;
-			 text-overflow: ellipsis;
-		 }
-	 }
- }
- 
- .ck-dropdown__panel {
-	 @mixin ck-rounded-corners;
-	 @mixin ck-drop-shadow;
- 
-	 @nest .ck-dropdown & {
-		 /* Disabled radius of top-left border to be consistent with .dropdown__button */
-		 border-top-left-radius: 0;
-	 }
-	 
-	 /* https://github.com/ckeditor/ckeditor5-theme-lark/pull/146 */
-	 overflow: hidden;
- 
-	 background: var(--ck-color-dropdown-panel-background);
-	 border: 1px solid var(--ck-color-dropdown-panel-border);
-	 bottom: 0;
- 
-	 /* Make sure the panel is at least as wide as the dropdown's button. */
-	 min-width: 100%;
- }
- 
+@import "../../../mixins/_rounded.css";
+@import "../../../mixins/_disabled.css";
+@import "../../../mixins/_shadow.css";
+
+:root {
+	--ck-dropdown-arrow-size: calc(0.5 * var(--ck-icon-size));
+}
+
+.ck-dropdown {
+	/* Enable font size inheritance, which allows fluid UI scaling. */
+	font-size: inherit;
+
+	& .ck-dropdown__arrow {
+		right: var(--ck-spacing-standard);
+		width: var(--ck-dropdown-arrow-size);
+	}
+
+	&.ck-disabled .ck-dropdown__arrow {
+		@mixin ck-disabled;
+	}
+
+	& .ck-button.ck-dropdown__button {
+		/* A space to accommodate the triangle. */
+		padding-right: calc(2.5 * var(--ck-spacing-standard));
+
+		&:not(.ck-button_with-text) {
+			/* Make sure dropdowns with just an icon have the right inner spacing */
+			padding-left: var(--ck-spacing-small);
+		}
+
+		/* https://github.com/ckeditor/ckeditor5-theme-lark/issues/70 */
+		&.ck-disabled .ck-button__label {
+			@mixin ck-disabled;
+		}
+
+		&.ck-on {
+			border-bottom-left-radius: 0;
+			border-bottom-right-radius: 0;
+		}
+
+		/* #23 */
+		& .ck-button__label {
+			width: 7em;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+	}
+}
+
+.ck-dropdown__panel {
+	@mixin ck-rounded-corners;
+	@mixin ck-drop-shadow;
+
+	@nest .ck-dropdown & {
+		/* Disabled radius of top-left border to be consistent with .dropdown__button */
+		border-top-left-radius: 0;
+	}
+
+	/* https://github.com/ckeditor/ckeditor5-theme-lark/pull/146 */
+	overflow: hidden;
+	
+	background: var(--ck-color-dropdown-panel-background);
+	border: 1px solid var(--ck-color-dropdown-panel-border);
+	bottom: 0;
+
+	/* Make sure the panel is at least as wide as the dropdown's button. */
+	min-width: 100%;
+}

--- a/theme/ckeditor5-ui/components/dropdown/dropdown.css
+++ b/theme/ckeditor5-ui/components/dropdown/dropdown.css
@@ -56,7 +56,8 @@
 	@mixin ck-rounded-corners;
 	@mixin ck-drop-shadow;
 
-	/* Disabled radius of top-left border to be consistent with .dropdown__button */
+	/* Disabled radius of top-left border to be consistent with .dropdown__button
+	https://github.com/ckeditor/ckeditor5/issues/816 */
 	@mixin ck-rounded-corners {
 		border-top-left-radius: 0;
 	}

--- a/theme/ckeditor5-ui/components/dropdown/dropdown.css
+++ b/theme/ckeditor5-ui/components/dropdown/dropdown.css
@@ -56,11 +56,11 @@
 	@mixin ck-rounded-corners;
 	@mixin ck-drop-shadow;
 
-	@nest .ck-dropdown & {
-		/* Disabled radius of top-left border to be consistent with .dropdown__button */
+	/* Disabled radius of top-left border to be consistent with .dropdown__button */
+	@mixin ck-rounded-corners {
 		border-top-left-radius: 0;
 	}
-	
+
 	background: var(--ck-color-dropdown-panel-background);
 	border: 1px solid var(--ck-color-dropdown-panel-border);
 	bottom: 0;

--- a/theme/ckeditor5-ui/components/dropdown/dropdown.css
+++ b/theme/ckeditor5-ui/components/dropdown/dropdown.css
@@ -38,6 +38,11 @@
 			@mixin ck-disabled;
 		}
 
+		&.ck-on {
+			border-bottom-left-radius: 0;
+			border-bottom-right-radius: 0;
+		}
+
 		/* #23 */
 		& .ck-button__label {
 			width: 7em;
@@ -51,11 +56,14 @@
 	@mixin ck-rounded-corners;
 	@mixin ck-drop-shadow;
 
+	@nest .ck-dropdown & {
+		/* Disabled radius of top-left border to be consistent with .dropdown__button */
+		border-top-left-radius: 0;
+	}
+
 	background: var(--ck-color-dropdown-panel-background);
 	border: 1px solid var(--ck-color-dropdown-panel-border);
-
-	/* Compensate double border from button and from box when positioned below the button. */
-	bottom: 1px;
+	bottom: 0;
 
 	/* Make sure the panel is at least as wide as the dropdown's button. */
 	min-width: 100%;

--- a/theme/ckeditor5-ui/components/dropdown/dropdown.css
+++ b/theme/ckeditor5-ui/components/dropdown/dropdown.css
@@ -60,9 +60,6 @@
 		/* Disabled radius of top-left border to be consistent with .dropdown__button */
 		border-top-left-radius: 0;
 	}
-
-	/* https://github.com/ckeditor/ckeditor5-theme-lark/pull/146 */
-	overflow: hidden;
 	
 	background: var(--ck-color-dropdown-panel-background);
 	border: 1px solid var(--ck-color-dropdown-panel-border);

--- a/theme/ckeditor5-ui/components/dropdown/dropdown.css
+++ b/theme/ckeditor5-ui/components/dropdown/dropdown.css
@@ -38,6 +38,7 @@
 			@mixin ck-disabled;
 		}
 
+		/* https://github.com/ckeditor/ckeditor5/issues/816 */
 		&.ck-on {
 			border-bottom-left-radius: 0;
 			border-bottom-right-radius: 0;

--- a/theme/ckeditor5-ui/components/dropdown/dropdown.css
+++ b/theme/ckeditor5-ui/components/dropdown/dropdown.css
@@ -3,68 +3,72 @@
  * For licensing, see LICENSE.md.
  */
 
-@import "../../../mixins/_rounded.css";
-@import "../../../mixins/_disabled.css";
-@import "../../../mixins/_shadow.css";
-
-:root {
-	--ck-dropdown-arrow-size: calc(0.5 * var(--ck-icon-size));
-}
-
-.ck-dropdown {
-	/* Enable font size inheritance, which allows fluid UI scaling. */
-	font-size: inherit;
-
-	& .ck-dropdown__arrow {
-		right: var(--ck-spacing-standard);
-		width: var(--ck-dropdown-arrow-size);
-	}
-
-	&.ck-disabled .ck-dropdown__arrow {
-		@mixin ck-disabled;
-	}
-
-	& .ck-button.ck-dropdown__button {
-		/* A space to accommodate the triangle. */
-		padding-right: calc(2.5 * var(--ck-spacing-standard));
-
-		&:not(.ck-button_with-text) {
-			/* Make sure dropdowns with just an icon have the right inner spacing */
-			padding-left: var(--ck-spacing-small);
-		}
-
-		/* https://github.com/ckeditor/ckeditor5-theme-lark/issues/70 */
-		&.ck-disabled .ck-button__label {
-			@mixin ck-disabled;
-		}
-
-		&.ck-on {
-			border-bottom-left-radius: 0;
-			border-bottom-right-radius: 0;
-		}
-
-		/* #23 */
-		& .ck-button__label {
-			width: 7em;
-			overflow: hidden;
-			text-overflow: ellipsis;
-		}
-	}
-}
-
-.ck-dropdown__panel {
-	@mixin ck-rounded-corners;
-	@mixin ck-drop-shadow;
-
-	@nest .ck-dropdown & {
-		/* Disabled radius of top-left border to be consistent with .dropdown__button */
-		border-top-left-radius: 0;
-	}
-
-	background: var(--ck-color-dropdown-panel-background);
-	border: 1px solid var(--ck-color-dropdown-panel-border);
-	bottom: 0;
-
-	/* Make sure the panel is at least as wide as the dropdown's button. */
-	min-width: 100%;
-}
+ @import "../../../mixins/_rounded.css";
+ @import "../../../mixins/_disabled.css";
+ @import "../../../mixins/_shadow.css";
+ 
+ :root {
+	 --ck-dropdown-arrow-size: calc(0.5 * var(--ck-icon-size));
+ }
+ 
+ .ck-dropdown {
+	 /* Enable font size inheritance, which allows fluid UI scaling. */
+	 font-size: inherit;
+ 
+	 & .ck-dropdown__arrow {
+		 right: var(--ck-spacing-standard);
+		 width: var(--ck-dropdown-arrow-size);
+	 }
+ 
+	 &.ck-disabled .ck-dropdown__arrow {
+		 @mixin ck-disabled;
+	 }
+ 
+	 & .ck-button.ck-dropdown__button {
+		 /* A space to accommodate the triangle. */
+		 padding-right: calc(2.5 * var(--ck-spacing-standard));
+ 
+		 &:not(.ck-button_with-text) {
+			 /* Make sure dropdowns with just an icon have the right inner spacing */
+			 padding-left: var(--ck-spacing-small);
+		 }
+ 
+		 /* https://github.com/ckeditor/ckeditor5-theme-lark/issues/70 */
+		 &.ck-disabled .ck-button__label {
+			 @mixin ck-disabled;
+		 }
+ 
+		 &.ck-on {
+			 border-bottom-left-radius: 0;
+			 border-bottom-right-radius: 0;
+		 }
+ 
+		 /* #23 */
+		 & .ck-button__label {
+			 width: 7em;
+			 overflow: hidden;
+			 text-overflow: ellipsis;
+		 }
+	 }
+ }
+ 
+ .ck-dropdown__panel {
+	 @mixin ck-rounded-corners;
+	 @mixin ck-drop-shadow;
+ 
+	 @nest .ck-dropdown & {
+		 /* Disabled radius of top-left border to be consistent with .dropdown__button */
+		 border-top-left-radius: 0;
+	 }
+	 
+	 /* https://github.com/ckeditor/ckeditor5-theme-lark/pull/146 */
+	 overflow: hidden;
+ 
+	 background: var(--ck-color-dropdown-panel-background);
+	 border: 1px solid var(--ck-color-dropdown-panel-border);
+	 bottom: 0;
+ 
+	 /* Make sure the panel is at least as wide as the dropdown's button. */
+	 min-width: 100%;
+ }
+ 

--- a/theme/ckeditor5-ui/components/dropdown/listdropdown.css
+++ b/theme/ckeditor5-ui/components/dropdown/listdropdown.css
@@ -3,9 +3,19 @@
  * For licensing, see LICENSE.md.
  */
 
-/* Using absolute units to make sure each element has the same height and padding.
-https://github.com/ckeditor/ckeditor5-heading/issues/63 */
-.ck-dropdown .ck-dropdown__panel .ck-list__item {
-	line-height: calc(.8*var(--ck-line-height-base)*var(--ck-font-size-base));
-	padding: calc(.4*var(--ck-line-height-base)*var(--ck-font-size-base));
+@import "../../../mixins/_rounded.css";
+
+.ck-dropdown .ck-dropdown__panel .ck-list {
+	/* Disabled radius of top-left border to be consistent with .dropdown__button
+	https://github.com/ckeditor/ckeditor5/issues/816 */
+	@mixin ck-rounded-corners {
+		border-top-left-radius: 0;
+	}
+
+	/* Using absolute units to make sure each element has the same height and padding.
+	https://github.com/ckeditor/ckeditor5-heading/issues/63 */
+	& > .ck-list__item {
+		line-height: calc(.8*var(--ck-line-height-base)*var(--ck-font-size-base));
+		padding: calc(.4*var(--ck-line-height-base)*var(--ck-font-size-base));
+	}
 }

--- a/theme/ckeditor5-ui/components/dropdown/splitbutton.css
+++ b/theme/ckeditor5-ui/components/dropdown/splitbutton.css
@@ -48,4 +48,16 @@
 			border-left-color: var(--ck-color-split-button-hover-border);
 		}
 	}
+
+	/* Don't round the bottom left and right corners of the buttons when "open"
+	https://github.com/ckeditor/ckeditor5/issues/816 */
+	&.ck-splitbutton_open {
+		& > .ck-splitbutton__action {
+			border-bottom-left-radius: 0;
+		}
+
+		& > .ck-splitbutton__arrow {
+			border-bottom-right-radius: 0;
+		}
+	}
 }

--- a/theme/ckeditor5-ui/components/dropdown/splitbutton.css
+++ b/theme/ckeditor5-ui/components/dropdown/splitbutton.css
@@ -52,12 +52,14 @@
 	/* Don't round the bottom left and right corners of the buttons when "open"
 	https://github.com/ckeditor/ckeditor5/issues/816 */
 	&.ck-splitbutton_open {
-		& > .ck-splitbutton__action {
-			border-bottom-left-radius: 0;
-		}
+		@mixin ck-rounded-corners {
+			& > .ck-splitbutton__action {
+				border-bottom-left-radius: 0;
+			}
 
-		& > .ck-splitbutton__arrow {
-			border-bottom-right-radius: 0;
+			& > .ck-splitbutton__arrow {
+				border-bottom-right-radius: 0;
+			}
 		}
 	}
 }

--- a/theme/ckeditor5-ui/components/list/list.css
+++ b/theme/ckeditor5-ui/components/list/list.css
@@ -8,7 +8,7 @@
 
 .ck-list {
 	@mixin ck-rounded-corners;
-	
+
 	list-style-type: none;
 	background: var(--ck-color-list-background);
 }

--- a/theme/ckeditor5-ui/components/list/list.css
+++ b/theme/ckeditor5-ui/components/list/list.css
@@ -7,6 +7,8 @@
 @import "../../../mixins/_shadow.css";
 
 .ck-list {
+	@mixin ck-rounded-corners;
+	
 	list-style-type: none;
 	background: var(--ck-color-list-background);
 }

--- a/theme/ckeditor5-ui/components/list/list.css
+++ b/theme/ckeditor5-ui/components/list/list.css
@@ -7,8 +7,6 @@
 @import "../../../mixins/_shadow.css";
 
 .ck-list {
-	@mixin ck-rounded-corners;
-
 	list-style-type: none;
 	background: var(--ck-color-list-background);
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Removed common (left bottom & top corner) border-radius of dropdown button & panel. Closes [ckeditor/ckeditor5#816](https://github.com/ckeditor/ckeditor5/issues/816).

---

### Additional information

### Before:
![screen shot 2018-02-19 at 12 19 37](https://user-images.githubusercontent.com/10219857/36377350-2df29024-1577-11e8-9fea-5435a826c637.png)

### After:
![screen shot 2018-02-19 at 12 01 24](https://user-images.githubusercontent.com/10219857/36377351-2e0ea1b0-1577-11e8-8cb4-944be041236b.png)
