### PR TITLE
T/134: Improved the visual styles of the split button when hovered or open

### DIFF
--- a/theme/ckeditor5-ui/components/dropdown/splitbutton.css
+++ b/theme/ckeditor5-ui/components/dropdown/splitbutton.css
@@ -5,6 +5,11 @@
 
 @import "../../../mixins/_rounded.css";
 
+:root {
+	--ck-color-split-button-hover-background: hsl(0, 0%, 92%);
+	--ck-color-split-button-hover-border: hsl(0, 0%, 70%);
+}
+
 .ck-splitbutton {
 	& > .ck-splitbutton__action {
 		/* Don't round the first button on the right side */
@@ -34,12 +39,13 @@
 	separation between both buttons. */
 	&.ck-splitbutton_open,
 	&:hover {
+		/* When the split button hovered as a whole, not as individual buttons. */
 		& > .ck-button:not(.ck-on):not(:hover) {
-			background: hsl(0, 0%, 92%);
+			background: var(--ck-color-split-button-hover-background);
 		}
 
 		& > .ck-splitbutton__arrow {
-			border-left-color: hsl(0, 0%, 70%);
+			border-left-color: var(--ck-color-split-button-hover-border);
 		}
 	}
 }

--- a/theme/ckeditor5-ui/components/dropdown/splitbutton.css
+++ b/theme/ckeditor5-ui/components/dropdown/splitbutton.css
@@ -15,9 +15,6 @@
 	}
 
 	& > .ck-splitbutton__arrow {
-		/* Disable a double border between the button and the arrow button. */
-		border-left: 0;
-
 		/* It's a text-less button but still, it should not be square. */
 		min-width: unset;
 
@@ -29,6 +26,20 @@
 
 		& svg {
 			width: var(--ck-dropdown-arrow-size);
+		}
+	}
+
+	/* When the split button is "open" (the arrow is on) or being hovered, it should get some styling
+	as a whole. The background of both buttons should stand out and there should be a visual
+	separation between both buttons. */
+	&.ck-splitbutton_open,
+	&:hover {
+		& > .ck-button:not(.ck-on):not(:hover) {
+			background: hsl(0, 0%, 92%);
+		}
+
+		& > .ck-splitbutton__arrow {
+			border-left-color: hsl(0, 0%, 70%);
 		}
 	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Improved the visual styles of the split button when hovered or open. Closes #134.

---

### Additional information

* Requires https://github.com/ckeditor/ckeditor5-ui/pull/373.

## Demo

![kapture 2018-02-19 at 18 41 12](https://user-images.githubusercontent.com/1099479/36390810-855316fe-15a4-11e8-95ee-4b66af7528d7.gif)
