### PR TITLE
t/148b: Moved the visual .ck-icon styles from ckeditor5-ui.

### DIFF
--- a/theme/ckeditor5-ui/components/icon/icon.css
+++ b/theme/ckeditor5-ui/components/icon/icon.css
@@ -10,4 +10,26 @@
 svg.ck-icon {
 	width: var(--ck-icon-size);
 	height: var(--ck-icon-size);
+
+	/* Multiplied by the height of the line in "px" should give SVG "viewport" dimensions */
+	font-size: .8333350694em;
+
+	color: inherit;
+
+	/* Inherit cursor style (#5). */
+	cursor: inherit;
+
+	/* This will prevent blurry icons on Firefox. See #340. */
+	will-change: transform;
+
+	& * {
+		/* Inherit cursor style (#5). */
+		cursor: inherit;
+
+		/* Allows dynamic coloring of the icons. */
+		color: inherit;
+
+		/* Needed by FF. */
+		fill: currentColor;
+	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Fixed the coloring issue with the multi-color icons. Additionally, moved the visual `.ck-icon` styles from `ckeditor5-ui`. Closes #148.

---

### Additional information

#### A full scope

* Added the `IconView#fillColor` observable which handles the coloring of `.ck-icon__fill`.
* Made the `ButtonView#IconView` always present, so highlight can easily bind the `#fillColor`
* Made the highlight use the `IconView#fillColor` API instead of weak CSS inheritance hacks.

#### Requires

* https://github.com/ckeditor/ckeditor5-ui/pull/374
* https://github.com/ckeditor/ckeditor5-highlight/pull/12

<img width="575" alt="screen shot 2018-02-22 at 13 13 28" src="https://user-images.githubusercontent.com/1099479/36539960-d8aba9d4-17d8-11e8-9e33-6514184d73c6.png">