### PR TITLE
t/159: The selected link element should not resemble the native selection

### DIFF
--- a/theme/ckeditor5-link/link.css
+++ b/theme/ckeditor5-link/link.css
@@ -6,5 +6,4 @@
 /* Class added to span element surrounding currently selected link. */
 .ck-link_selected {
 	background: var(--ck-color-link-selected-background);
-	box-shadow: 0 0 0 2px var(--ck-color-link-selected-background);
 }

--- a/theme/ckeditor5-link/link.css
+++ b/theme/ckeditor5-link/link.css
@@ -6,5 +6,5 @@
 /* Class added to span element surrounding currently selected link. */
 .ck-link_selected {
 	background: var(--ck-color-link-selected-background);
-	outline: 1px solid var(--ck-color-link-selected-background);
+	box-shadow: 0 0 0 2px var(--ck-color-link-selected-background);
 }

--- a/theme/ckeditor5-ui/globals/_colors.css
+++ b/theme/ckeditor5-ui/globals/_colors.css
@@ -94,5 +94,5 @@
 	/* -- Link -------------------------------------------------------------------------------- */
 
 	--ck-color-link-default:									hsl(240, 100%, 47%);
-	--ck-color-link-selected-background:						hsl(201, 93%, 89%);
+	--ck-color-link-selected-background: 						hsl(201, 100%, 96%);
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The selected link element should not resemble the native selection. Closes #159.
