### PR TITLE
Fixed difference of padding between steps in the link panel.

### DIFF
--- a/theme/ckeditor5-link/linkactions.css
+++ b/theme/ckeditor5-link/linkactions.css
@@ -33,7 +33,7 @@
 		}
 
 		& .ck-button__label {
-			padding: 0 var(--ck-spacing-standard);
+			padding: 0 var(--ck-spacing-medium);
 			color: var(--ck-color-link-default);
 			text-overflow: ellipsis;
 			cursor: pointer;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Unified different padding between steps in the link panel. Closes #165.

---

### Additional information

It's not a pixel perfect solution, but now there is no such big "dancing effect". 
