### PR TITLE
t/178: The arrow of the balloon holding a toolbar should have the same background color as the toolbar

### DIFF
--- a/theme/ckeditor5-ui/components/editorui/editorui.css
+++ b/theme/ckeditor5-ui/components/editorui/editorui.css
@@ -35,13 +35,13 @@
 }
 
 /* https://github.com/ckeditor/ckeditor5-theme-lark/issues/111 */
-.ck.ck-toolbar-container[class*="arrow_n"] {
+.ck.ck-balloon-panel.ck-toolbar-container[class*="arrow_n"] {
 	&::after {
 		border-bottom-color: var(--ck-color-base-foreground);
 	}
 }
 
-.ck.ck-toolbar-container[class*="arrow_s"] {
+.ck.ck-balloon-panel.ck-toolbar-container[class*="arrow_s"] {
 	&::after {
 		border-top-color: var(--ck-color-base-foreground);
 	}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The arrow of the balloon holding a toolbar should have the same background color as the toolbar. Closes #178.