### PR TITLE
Fix: The table cell selection highlight is broken on merged cells.

### DIFF
--- a/theme/ckeditor5-table/tableediting.css
+++ b/theme/ckeditor5-table/tableediting.css
@@ -17,7 +17,9 @@
 			/* Fixes the problem where surrounding cells cover the focused cell's border.
 			It does not fix the problem in all places but the UX is improved.
 			See https://github.com/ckeditor/ckeditor5-table/issues/29. */
-			border-style: double;
+			border-style: none;
+			outline: 1px solid var(--ck-color-focus-border);
+			outline-offset: -1px; /* progressive enhancement - no IE support */
 		}
 	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The table cell selection highlight is broken on merged cells. Closes ckeditor/ckeditor5-table#69. Closes ckeditor/ckeditor5-table#29

---

### Additional information

* Finally the table cell selection is not broken anymore :)
* See https://github.com/ckeditor/ckeditor5-table/issues/69#issuecomment-399073685 for browsers comparison of available solutions.