### PR TITLE
Added maximum height of `.ck-dropdown__panel`.

### DIFF
--- a/theme/ckeditor5-ui/components/dropdown/dropdown.css
+++ b/theme/ckeditor5-ui/components/dropdown/dropdown.css
@@ -9,6 +9,7 @@
 
 :root {
 	--ck-dropdown-arrow-size: calc(0.5 * var(--ck-icon-size));
+	--ck-dropdown-panel-max-height: 70vh;
 }
 
 .ck.ck-dropdown {
@@ -56,6 +57,10 @@
 .ck.ck-dropdown__panel {
 	@mixin ck-rounded-corners;
 	@mixin ck-drop-shadow;
+
+	/* https://github.com/ckeditor/ckeditor5/issues/952 */
+	max-height: var(--ck-dropdown-panel-max-height);
+	overflow-y: auto;
 
 	/* Disabled radius of top-left border to be consistent with .dropdown__button
 	https://github.com/ckeditor/ckeditor5/issues/816 */


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `DropdownPanelView` panel should properly display overflowed content. Added `--ck-dropdown-panel-max-height` CSS variable to handle maximum height of panel. Closes https://github.com/ckeditor/ckeditor5/issues/952

---

### Additional information

After:
<img width="749" alt="screen shot 2018-07-03 at 14 09 08" src="https://user-images.githubusercontent.com/10219857/42219168-3628520c-7ecb-11e8-9d29-1b7690a0c125.png">
