### PR TITLE
Revert "Added maximum height of `.ck-dropdown__panel`."

### DIFF
--- a/theme/ckeditor5-ui/components/dropdown/dropdown.css
+++ b/theme/ckeditor5-ui/components/dropdown/dropdown.css
@@ -9,7 +9,6 @@
 
 :root {
 	--ck-dropdown-arrow-size: calc(0.5 * var(--ck-icon-size));
-	--ck-dropdown-panel-max-height: 70vh;
 }
 
 .ck.ck-dropdown {
@@ -57,10 +56,6 @@
 .ck.ck-dropdown__panel {
 	@mixin ck-rounded-corners;
 	@mixin ck-drop-shadow;
-
-	/* https://github.com/ckeditor/ckeditor5/issues/952 */
-	max-height: var(--ck-dropdown-panel-max-height);
-	overflow-y: auto;
 
 	/* Disabled radius of top-left border to be consistent with .dropdown__button
 	https://github.com/ckeditor/ckeditor5/issues/816 */


### PR DESCRIPTION
Because of #191 we need to revert change with maximum height and overflow of `ck-dropdown`. 

At this moment there is no way to fix it, firstly we need to use `BalloonPanelView` for tooltips.

Reverts ckeditor/ckeditor5-theme-lark#186