### PR TITLE
[Edge] Switch button is animated properly in Edge

### DIFF
--- a/theme/ckeditor5-ui/components/button/switchbutton.css
+++ b/theme/ckeditor5-ui/components/button/switchbutton.css
@@ -59,8 +59,16 @@ of the component, floating–point numbers have been used which, for the default
 		background: var(--ck-color-switch-button-on-background);
 
 		& .ck-button__toggle__inner {
-			/* Move the toggle switch to the right. It will be animated. */
-			transform: translateX(calc(var(--ck-switch-button-toggle-width) - var(--ck-switch-button-toggle-inner-size) - 2*var(--ck-switch-button-toggle-spacing)));
+			/*
+			 * Move the toggle switch to the right. It will be animated.
+			 * ckeditor5-ui#433. Edge is not supporting calc() in the transitions and animations, we need to hardcode this value.
+			 * translateX( calc(
+					var(--ck-switch-button-toggle-width) -
+					var(--ck-switch-button-toggle-inner-size) -
+					2*var(--ck-switch-button-toggle-spacing) )
+				);
+			 */
+			transform: translateX( 1.3846153847em );
 		}
 	}
 }

--- a/theme/ckeditor5-ui/components/button/switchbutton.css
+++ b/theme/ckeditor5-ui/components/button/switchbutton.css
@@ -61,12 +61,15 @@ of the component, floating–point numbers have been used which, for the default
 		& .ck-button__toggle__inner {
 			/*
 			 * Move the toggle switch to the right. It will be animated.
-			 * ckeditor5-ui#433. Edge is not supporting calc() in the transitions and animations, we need to hardcode this value.
-			 * translateX( calc(
-					var(--ck-switch-button-toggle-width) -
-					var(--ck-switch-button-toggle-inner-size) -
-					2*var(--ck-switch-button-toggle-spacing) )
-				);
+			 *
+			 * Edge is not supporting calc() in the transitions and animations, we need to hardcode this value (see ckeditor5-ui#433).
+			 * It boils down to:
+			 *
+			 * 	calc(
+			 * 		var(--ck-switch-button-toggle-width) -
+			 * 		var(--ck-switch-button-toggle-inner-size) -
+			 * 		2*var(--ck-switch-button-toggle-spacing) )
+			 * 	)
 			 */
 			transform: translateX( 1.3846153847em );
 		}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Switch button should be animated properly in Microsoft Edge. Closes https://github.com/ckeditor/ckeditor5-ui/issues/433.


