### PR TITLE
t/ckeditor5–media–embed/1: Added styles for errors in the labeled inputs

### DIFF
--- a/tests/manual/iconset.js
+++ b/tests/manual/iconset.js
@@ -48,6 +48,8 @@ import unlink from '@ckeditor/ckeditor5-link/theme/icons/unlink.svg';
 import bulletedList from '@ckeditor/ckeditor5-list/theme/icons/bulletedlist.svg';
 import numberedList from '@ckeditor/ckeditor5-list/theme/icons/numberedlist.svg';
 
+import media from '@ckeditor/ckeditor5-media-embed/theme/icons/media.svg';
+
 import paragraph from '@ckeditor/ckeditor5-paragraph/theme/icons/paragraph.svg';
 
 import table from '@ckeditor/ckeditor5-table/theme/icons/table.svg';
@@ -84,6 +86,9 @@ const icons = {
 
 	// list
 	bulletedList, numberedList,
+
+	// media-embed
+	media,
 
 	// paragraph
 	paragraph,

--- a/theme/ckeditor5-media-embed/mediaform.css
+++ b/theme/ckeditor5-media-embed/mediaform.css
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+.ck.ck-media-form {
+	padding: var(--ck-spacing-standard);
+
+	&:focus {
+		outline: none;
+	}
+
+	& > :not(:first-child) {
+		margin-left: var(--ck-spacing-standard);
+	}
+}

--- a/theme/ckeditor5-ui/components/inputtext/inputtext.css
+++ b/theme/ckeditor5-ui/components/inputtext/inputtext.css
@@ -42,4 +42,12 @@
 			@mixin ck-box-shadow var(--ck-focus-disabled-outer-shadow), var(--ck-inner-shadow);
 		}
 	}
+
+	&.ck-error {
+		border-color: var(--ck-color-input-error-border);
+
+		&:focus {
+			@mixin ck-box-shadow var(--ck-focus-error-outer-shadow), var(--ck-inner-shadow);
+		}
+	}
 }

--- a/theme/ckeditor5-ui/components/labeledinput/labeledinput.css
+++ b/theme/ckeditor5-ui/components/labeledinput/labeledinput.css
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+.ck.ck-labeled-input .ck-labeled-input__error {
+	font-size: var(--ck-font-size-small);
+	color: var(--ck-color-base-error);
+}

--- a/theme/ckeditor5-ui/globals/_colors.css
+++ b/theme/ckeditor5-ui/globals/_colors.css
@@ -12,12 +12,14 @@
 	--ck-color-base-text: 										hsl(0, 0%, 20%);
 	--ck-color-base-active: 									hsl(208, 88%, 52%);
 	--ck-color-base-active-focus:								hsl(208, 88%, 47%);
+	--ck-color-base-error:										hsl(15, 100%, 43%);
 
 	/* -- Generic colors ------------------------------------------------------------------------ */
 
 	--ck-color-focus-border: 									hsl(208, 90%, 62%);
 	--ck-color-focus-shadow:									hsla(209, 90%, 72%,.5);
 	--ck-color-focus-disabled-shadow:							hsla(209, 90%, 72%,.3);
+	--ck-color-focus-error-shadow:								hsla(9,100%,56%,.3);
 	--ck-color-text: 											var(--ck-color-base-text);
 	--ck-color-shadow-drop: 									hsla(0, 0%, 0%, 0.15);
 	--ck-color-shadow-inner: 									hsla(0, 0%, 0%, 0.1);
@@ -59,6 +61,7 @@
 
 	--ck-color-input-background: 								var(--ck-color-base-background);
 	--ck-color-input-border: 									hsl(0, 0%, 78%);
+	--ck-color-input-error-border:								var(--ck-color-base-error);
 	--ck-color-input-text: 										var(--ck-color-base-text);
 	--ck-color-input-disabled-background: 						hsl(0, 0%, 95%);
 	--ck-color-input-disabled-border: 							hsl(0, 0%, 78%);

--- a/theme/ckeditor5-ui/globals/_focus.css
+++ b/theme/ckeditor5-ui/globals/_focus.css
@@ -20,6 +20,11 @@
 	--ck-focus-disabled-outer-shadow: var(--ck-focus-outer-shadow-geometry) var(--ck-color-focus-disabled-shadow);
 
 	/**
+	 * A visual style of focused element's outer shadow (when has errors).
+	 */
+	--ck-focus-error-outer-shadow: var(--ck-focus-outer-shadow-geometry) var(--ck-color-focus-error-shadow);
+
+	/**
 	 * A visual style of focused element's border or outline.
 	 */
 	--ck-focus-ring: 1px solid var(--ck-color-focus-border);


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added styles for errors in the labeled inputs. Added media icon to the `iconset` manual test (see ckeditor/ckeditor5-media-embed#1).

----

**A piece of https://github.com/ckeditor/ckeditor5-media-embed/pull/2 constellation.**