### PR TITLE
t/ckeditor/ckeditor5-ui/443: Removed the initial transform property of the text input with an error to allow the shake animation in Safari

### DIFF
--- a/theme/ckeditor5-ui/components/inputtext/inputtext.css
+++ b/theme/ckeditor5-ui/components/inputtext/inputtext.css
@@ -46,7 +46,6 @@
 	&.ck-error {
 		border-color: var(--ck-color-input-error-border);
 		animation: ck-text-input-shake .3s ease both;
-		transform: translateX(0);
 
 		&:focus {
 			@mixin ck-box-shadow var(--ck-focus-error-outer-shadow), var(--ck-inner-shadow);


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Removed the initial transform property of the text input with an error to allow the shake animation in Safari. Closes ckeditor/ckeditor5-ui#443.
