### PR TITLE
Improved visibility of selected link inside table cell.

### DIFF
--- a/theme/ckeditor5-table/tableediting.css
+++ b/theme/ckeditor5-table/tableediting.css
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
- :root {
+:root {
 	--ck-color-table-focused-cell-background: hsl(208, 90%, 98%);
 	--ck-color-link-selected-inside-table-background: hsl(201, 100%, 92%);
 }

--- a/theme/ckeditor5-table/tableediting.css
+++ b/theme/ckeditor5-table/tableediting.css
@@ -5,7 +5,6 @@
 
 :root {
 	--ck-color-table-focused-cell-background: hsl(208, 90%, 98%);
-	--ck-color-link-selected-inside-table-background: hsl(201, 100%, 92%);
 }
 
 .ck-widget.table {
@@ -22,11 +21,5 @@
 			outline: 1px solid var(--ck-color-focus-border);
 			outline-offset: -1px; /* progressive enhancement - no IE support */
 		}
-	}
-
-	/* Improve visibility of selected link inside table cell.
-	See https://github.com/ckeditor/ckeditor5-link/issues/204. */
-	& .ck-link_selected {
-		background: var(--ck-color-link-selected-inside-table-background);
 	}
 }

--- a/theme/ckeditor5-table/tableediting.css
+++ b/theme/ckeditor5-table/tableediting.css
@@ -3,8 +3,9 @@
  * For licensing, see LICENSE.md.
  */
 
-:root {
+ :root {
 	--ck-color-table-focused-cell-background: hsl(208, 90%, 98%);
+	--ck-color-link-selected-inside-table-background: hsl(201, 100%, 92%);
 }
 
 .ck-widget.table {
@@ -21,5 +22,11 @@
 			outline: 1px solid var(--ck-color-focus-border);
 			outline-offset: -1px; /* progressive enhancement - no IE support */
 		}
+	}
+
+	/* Improve visibility of selected link inside table cell.
+	See https://github.com/ckeditor/ckeditor5-link/issues/204. */
+	& .ck-link_selected {
+		background: var(--ck-color-link-selected-inside-table-background);
 	}
 }

--- a/theme/ckeditor5-ui/globals/_colors.css
+++ b/theme/ckeditor5-ui/globals/_colors.css
@@ -102,5 +102,5 @@
 	/* -- Link -------------------------------------------------------------------------------- */
 
 	--ck-color-link-default:									hsl(240, 100%, 47%);
-	--ck-color-link-selected-background: 						hsl(201, 100%, 96%);
+	--ck-color-link-selected-background: 						hsla(201, 100%, 56%, 0.1);
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Improved visibility of selected link inside the table cell. Closes https://github.com/ckeditor/ckeditor5-link/issues/204.

---

### Additional information

I had some doubts about placing new color. I'm not so sure if this (`tableediting.css`) is better place than global directory with colors - `theme-lark/globals/_colors.css`.

#### Before:
<img width="304" alt="screenshot 2018-10-30 at 12 07 13" src="https://user-images.githubusercontent.com/10219857/47714216-94f47f80-dc3c-11e8-96e1-6b61b04b3e1d.png">

#### ... and after:
<img width="328" alt="screenshot 2018-10-30 at 12 15 17" src="https://user-images.githubusercontent.com/10219857/47714559-7c389980-dc3d-11e8-92a0-86d169d183a6.png">

