### PR TITLE
Don't set fill for icons that set declare it

### DIFF
--- a/theme/ckeditor5-ui/components/icon/icon.css
+++ b/theme/ckeditor5-ui/components/icon/icon.css
@@ -29,7 +29,9 @@
 		/* Allows dynamic coloring of the icons. */
 		color: inherit;
 
-		/* Needed by FF. */
-		fill: currentColor;
+		:not([fill]) {
+				/* Needed by FF. */
+				fill: currentColor;
+		}
 	}
 }

--- a/theme/ckeditor5-ui/components/icon/icon.css
+++ b/theme/ckeditor5-ui/components/icon/icon.css
@@ -29,7 +29,7 @@
 		/* Allows dynamic coloring of the icons. */
 		color: inherit;
 
-		:not([fill]) {
+		&:not([fill]) {
 				/* Needed by FF. */
 				fill: currentColor;
 		}


### PR DESCRIPTION
Only override the fill for elements that don't declare one.
Closes #206

