### PR TITLE
t/ckeditor5/1348: Used the getViewportTopOffsetConfig helper in the code snippets.

### DIFF
--- a/docs/_snippets/examples/theme-lark.js
+++ b/docs/_snippets/examples/theme-lark.js
@@ -16,7 +16,7 @@ ClassicEditor
 		plugins: [ ArticlePluginSet, EasyImage ],
 		toolbar: {
 			items: [ 'heading', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo' ],
-			viewportTopOffset: 100
+			viewportTopOffset: window.getViewportTopOffsetConfig()
 		},
 		image: {
 			toolbar: [ 'imageStyle:full', 'imageStyle:side', '|', 'imageTextAlternative' ]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Used the `getViewportTopOffsetConfig` helper in the code snippets to make sure the toolbar top offset is correct regardless of the page layout (see ckeditor/ckeditor5#1348).

---

### Additional information

This PR is a piece of the https://github.com/ckeditor/ckeditor5/pull/1360 constellation.
