### PR TITLE
Truncating table selection handler 

### DIFF
--- a/theme/ckeditor5-table/tableediting.css
+++ b/theme/ckeditor5-table/tableediting.css
@@ -26,8 +26,8 @@
 
 .ck-editor__editable > .table:first-child,
 .ck-editor__editable blockquote > .table:first-child {
-	/* `16px` = var(--ck-widget-handler-icon-size) - table selection handler height.
+	/* Do not truncate selection handler if table is a first-child in the blockquote or content.
 	https://github.com/ckeditor/ckeditor5-block-quote/issues/28
 	https://github.com/ckeditor/ckeditor5-widget/issues/44 */
-	margin-top: calc(1em + var(--ck-widget-handler-icon-size) );
+	margin-top: calc(1em + var(--ck-widget-handler-icon-size));
 }

--- a/theme/ckeditor5-table/tableediting.css
+++ b/theme/ckeditor5-table/tableediting.css
@@ -23,3 +23,11 @@
 		}
 	}
 }
+
+.ck-editor__editable > .table:first-child,
+.ck-editor__editable blockquote > .table:first-child {
+	/* `16px` = var(--ck-widget-handler-icon-size) - table selection handler height.
+	https://github.com/ckeditor/ckeditor5-block-quote/issues/28
+	https://github.com/ckeditor/ckeditor5-widget/issues/44 */
+	margin-top: calc(1em + var(--ck-widget-handler-icon-size) );
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Table selection handler should not be truncated if it is a first-child in the block quote or the content. Closes https://github.com/ckeditor/ckeditor5-block-quote/issues/28.

---

### Additional information

1. [Check table inside table case - fiddlejs demo](https://jsfiddle.net/8rzk7axb/1/) 

2. I've checked it on Edge and actually `calc()` with CSS Variables works fine (even adding `em` to the `px`!)