### PR TITLE
t/ckeditor5-widget/66: Renamed the `.ck-widget_selectable` class to `.ck-widget_with-selection-handler`

### DIFF
--- a/theme/ckeditor5-table/tableediting.css
+++ b/theme/ckeditor5-table/tableediting.css
@@ -23,11 +23,3 @@
 		}
 	}
 }
-
-.ck-editor__editable > .table:first-child,
-.ck-editor__editable blockquote > .table:first-child {
-	/* Do not truncate selection handler if table is a first-child in the blockquote or content.
-	https://github.com/ckeditor/ckeditor5-block-quote/issues/28
-	https://github.com/ckeditor/ckeditor5-widget/issues/44 */
-	margin-top: calc(1em + var(--ck-widget-handler-icon-size));
-}

--- a/theme/ckeditor5-widget/widget.css
+++ b/theme/ckeditor5-widget/widget.css
@@ -48,7 +48,17 @@
 	}
 }
 
-.ck .ck-widget.ck-widget_selectable {
+.ck-editor__editable > .ck-widget.ck-widget_with-selection-handler:first-child,
+.ck-editor__editable blockquote > .ck-widget.ck-widget_with-selection-handler:first-child {
+	/* Do not crop selection handler if a widget is a first-child in the blockquote or in the root editable.
+	In fact, anything with overflow: hidden.
+	https://github.com/ckeditor/ckeditor5-block-quote/issues/28
+	https://github.com/ckeditor/ckeditor5-widget/issues/44
+	https://github.com/ckeditor/ckeditor5-widget/issues/66 */
+	margin-top: calc(1em + var(--ck-widget-handler-icon-size));
+}
+
+.ck .ck-widget.ck-widget_with-selection-handler {
 	& .ck-widget__selection-handler {
 		padding: 4px;
 		box-sizing: border-box;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Renamed the `.ck-widget_selectable` class to `.ck-widget_with-selection-handler` for better semantics. Made the selection handler crop fix introduced in #214 generic for all widgets (see ckeditor/ckeditor5-widget#66).

---

### Additional information

Requires https://github.com/ckeditor/ckeditor5-widget/pull/67.
