### PR TITLE
Background of hover list should has proper contrast

### DIFF
--- a/theme/ckeditor5-ui/globals/_colors.css
+++ b/theme/ckeditor5-ui/globals/_colors.css
@@ -71,8 +71,8 @@
 	/* -- List ---------------------------------------------------------------------------------- */
 
 	--ck-color-list-background: 								var(--ck-color-base-background);
-	--ck-color-list-button-hover-background: 					var(--ck-color-base-foreground);
-	--ck-color-list-button-on-background: 						var(--ck-color-base-active);
+	--ck-color-list-button-hover-background: 					var(--ck-color-button-default-hover-background);
+	--ck-color-list-button-on-background: 						var(--ck-color-button-default-active-background);
 	--ck-color-list-button-on-background-focus: 				var(--ck-color-base-active-focus);
 	--ck-color-list-button-on-text:								var(--ck-color-base-background);
 

--- a/theme/ckeditor5-ui/globals/_colors.css
+++ b/theme/ckeditor5-ui/globals/_colors.css
@@ -72,7 +72,7 @@
 
 	--ck-color-list-background: 								var(--ck-color-base-background);
 	--ck-color-list-button-hover-background: 					var(--ck-color-button-default-hover-background);
-	--ck-color-list-button-on-background: 						var(--ck-color-button-default-active-background);
+	--ck-color-list-button-on-background: 						var(--ck-color-base-active);
 	--ck-color-list-button-on-background-focus: 				var(--ck-color-base-active-focus);
 	--ck-color-list-button-on-text:								var(--ck-color-base-background);
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Background of hover list should has proper contrast. Closes #219.

---

### Additional information

<img width="542" alt="screenshot 2019-02-08 at 17 05 55" src="https://user-images.githubusercontent.com/10219857/52489966-f2955200-2bc3-11e9-89ce-9c0c10585f16.png">

<img width="499" alt="screenshot 2019-02-08 at 17 07 43" src="https://user-images.githubusercontent.com/10219857/52490027-19538880-2bc4-11e9-87ac-86482d612af5.png">
