### PR TITLE
t/168: Fix: Vertical toolbar items should have no border radius.

### DIFF
--- a/theme/ckeditor5-ui/components/toolbar/toolbar.css
+++ b/theme/ckeditor5-ui/components/toolbar/toolbar.css
@@ -25,7 +25,7 @@
 		/* Items in a vertical toolbar span the entire width. */
 		padding: 0;
 
-		& > * {
+		& > .ck {
 			/* Items in a vertical toolbar should span the horizontal space. */
 			width: 100%;
 

--- a/theme/ckeditor5-ui/components/toolbar/toolbar.css
+++ b/theme/ckeditor5-ui/components/toolbar/toolbar.css
@@ -25,6 +25,7 @@
 		/* Items in a vertical toolbar span the entire width. */
 		padding: 0;
 
+		/* Specificity matters here. See https://github.com/ckeditor/ckeditor5-theme-lark/issues/168. */
 		& > .ck {
 			/* Items in a vertical toolbar should span the horizontal space. */
 			width: 100%;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Vertical toolbar items should have no border-radius. Closes #168.

---

You can test it in alignment feature MTs.
