### PR TITLE
Fix css of splitbutton in readonly mode

### DIFF
--- a/theme/ckeditor5-ui/components/dropdown/splitbutton.css
+++ b/theme/ckeditor5-ui/components/dropdown/splitbutton.css
@@ -41,11 +41,11 @@
 	&.ck-splitbutton_open,
 	&:hover {
 		/* When the split button hovered as a whole, not as individual buttons. */
-		& > .ck-button:not(.ck-on):not(:hover) {
+		& > .ck-button:not(.ck-on):not(.ck-disabled):not(:hover) {
 			background: var(--ck-color-split-button-hover-background);
 		}
 
-		& > .ck-splitbutton__arrow {
+		& > .ck-splitbutton__arrow:not(.ck-disabled) {
 			border-left-color: var(--ck-color-split-button-hover-border);
 		}
 	}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Background behavior of splitbutton in read-only mode. Closes ckeditor/ckeditor5#943.