### PR TITLE
Introduced styles for `LinkFormView` with manual decorators.

### DIFF
--- a/theme/ckeditor5-link/linkform.css
+++ b/theme/ckeditor5-link/linkform.css
@@ -46,7 +46,8 @@
 	}
 }
 
-/* Style link form differently when manual decoratos are available.
+/*
+ * Style link form differently when manual decorators are available.
  * See: https://github.com/ckeditor/ckeditor5-link/issues/186.
  */
 .ck.ck-link-form_layout-vertical {

--- a/theme/ckeditor5-link/linkform.css
+++ b/theme/ckeditor5-link/linkform.css
@@ -46,3 +46,43 @@
 	}
 }
 
+/* Style link form differently when manual decoratos are available.
+ * See: https://github.com/ckeditor/ckeditor5-link/issues/186.
+ */
+.ck.ck-link-form_decorators {
+	padding: 0;
+	width: var(--ck-input-text-width);
+
+	& .ck-labeled-input {
+		margin: var(--ck-spacing-standard);
+
+		& .ck-input-text {
+			min-width: 0;
+			width: 100%;
+		}
+	}
+
+	& .ck-button {
+		padding: var(--ck-spacing-standard);
+		margin: 0;
+		border-radius: 0;
+		border: 0;
+		border-top: 1px solid var(--ck-color-base-border);
+
+		&:first-of-type {
+			border-right: 1px solid var(--ck-color-base-border);
+		}
+	}
+
+	& .ck-list .ck-switchbutton {
+		border: 0;
+	}
+
+	/* Do not allow stretching switch button label (it breaks switch button). */
+	& .ck-list .ck-button__label {
+		text-overflow: ellipsis;
+		overflow: hidden;
+		max-width: calc( var(--ck-input-text-width) * .8 - var(--ck-switch-button-toggle-width) );
+	}
+}
+

--- a/theme/ckeditor5-link/linkform.css
+++ b/theme/ckeditor5-link/linkform.css
@@ -74,6 +74,11 @@
 		}
 	}
 
+	/* Using additional `.ck` class for stronger CSS specificity than `.ck.ck-link-form > :not(:first-child)`. */
+	& .ck.ck-list {
+		margin-left: 0;
+	}
+
 	& .ck-list .ck-switchbutton {
 		border: 0;
 	}

--- a/theme/ckeditor5-link/linkform.css
+++ b/theme/ckeditor5-link/linkform.css
@@ -50,8 +50,9 @@
  * See: https://github.com/ckeditor/ckeditor5-link/issues/186.
  */
 .ck.ck-link-form_layout-vertical {
+	display: block;
 	padding: 0;
-	width: var(--ck-input-text-width);
+	min-width: var(--ck-input-text-width);
 
 	& .ck-labeled-input {
 		margin: var(--ck-spacing-standard);
@@ -68,6 +69,7 @@
 		border-radius: 0;
 		border: 0;
 		border-top: 1px solid var(--ck-color-base-border);
+		width: 50%;
 
 		&:first-of-type {
 			border-right: 1px solid var(--ck-color-base-border);
@@ -81,13 +83,6 @@
 
 	& .ck-list .ck-switchbutton {
 		border: 0;
-	}
-
-	/* Do not allow stretching switch button label (it breaks switch button). */
-	& .ck-list .ck-button__label {
-		text-overflow: ellipsis;
-		overflow: hidden;
-		max-width: calc( var(--ck-input-text-width) * .8 - var(--ck-switch-button-toggle-width) );
 	}
 }
 

--- a/theme/ckeditor5-link/linkform.css
+++ b/theme/ckeditor5-link/linkform.css
@@ -55,7 +55,7 @@
 	min-width: var(--ck-input-text-width);
 
 	& .ck-labeled-input {
-		margin: var(--ck-spacing-standard);
+		margin: var(--ck-spacing-standard) var(--ck-spacing-standard) var(--ck-spacing-small);
 
 		& .ck-input-text {
 			min-width: 0;
@@ -81,8 +81,12 @@
 		margin-left: 0;
 	}
 
-	& .ck-list .ck-switchbutton {
+	& .ck-list .ck-button.ck-switchbutton {
 		border: 0;
+
+		&:hover {
+			background: none;
+		}
 	}
 }
 

--- a/theme/ckeditor5-link/linkform.css
+++ b/theme/ckeditor5-link/linkform.css
@@ -51,7 +51,6 @@
  * See: https://github.com/ckeditor/ckeditor5-link/issues/186.
  */
 .ck.ck-link-form_layout-vertical {
-	display: block;
 	padding: 0;
 	min-width: var(--ck-input-text-width);
 

--- a/theme/ckeditor5-link/linkform.css
+++ b/theme/ckeditor5-link/linkform.css
@@ -49,7 +49,7 @@
 /* Style link form differently when manual decoratos are available.
  * See: https://github.com/ckeditor/ckeditor5-link/issues/186.
  */
-.ck.ck-link-form_decorators {
+.ck.ck-link-form_layout-vertical {
 	padding: 0;
 	width: var(--ck-input-text-width);
 

--- a/theme/ckeditor5-ui/components/button/switchbutton.css
+++ b/theme/ckeditor5-ui/components/button/switchbutton.css
@@ -39,6 +39,14 @@ of the component, floating–point numbers have been used which, for the default
 		width: var(--ck-switch-button-toggle-width);
 		background: var(--ck-color-switch-button-off-background);
 
+		&:hover {
+			background: var(--ck-color-switch-button-off-hover-background);
+
+			& .ck-button__toggle__inner {
+				box-shadow: 0 0 0 5px var(--ck-color-switch-button-inner-shadow);
+			}
+		}
+
 		& .ck-button__toggle__inner {
 			@mixin ck-rounded-corners {
 				border-radius: calc(.5*var(--ck-border-radius));
@@ -51,12 +59,16 @@ of the component, floating–point numbers have been used which, for the default
 			background: var(--ck-color-switch-button-inner-background);
 
 			/* Gently animate the inner part of the toggle switch */
-			transition: transform 300ms ease;
+			transition: all 300ms ease;
 		}
 	}
 
 	&.ck-on .ck-button__toggle {
 		background: var(--ck-color-switch-button-on-background);
+
+		&:hover {
+			background: var(--ck-color-switch-button-on-hover-background);
+		}
 
 		& .ck-button__toggle__inner {
 			/*

--- a/theme/ckeditor5-ui/globals/_colors.css
+++ b/theme/ckeditor5-ui/globals/_colors.css
@@ -50,8 +50,11 @@
 	--ck-color-button-cancel: 									hsl(15, 100%, 43%);
 
 	--ck-color-switch-button-off-background:					hsl(0, 0%, 69%);
+	--ck-color-switch-button-off-hover-background:				hsl(0, 0%, 64%);
 	--ck-color-switch-button-on-background:						var(--ck-color-button-action-background);
+	--ck-color-switch-button-on-hover-background:				hsl(104, 44%, 43%);
 	--ck-color-switch-button-inner-background:					var(--ck-color-base-background);
+	--ck-color-switch-button-inner-shadow:						hsla(0, 0%, 0%, 0.1);
 
 	/* -- Dropdown ------------------------------------------------------------------------------ */
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced styles for `LinkFormView` with manual decorators. Closes https://github.com/ckeditor/ckeditor5-link/issues/186.

---

### Additional information

Required: https://github.com/ckeditor/ckeditor5-link/pull/222

<img width="830" alt="Screenshot 2019-06-13 at 13 48 16" src="https://user-images.githubusercontent.com/10219857/59430201-eaebf100-8de1-11e9-93c0-7f29c2582ffe.png">
