### PR TITLE
t/ckeditor5/1802: Tooltips should not render blurry in LoDPI environments.

### DIFF
--- a/theme/ckeditor5-ui/components/tooltip/tooltip.css
+++ b/theme/ckeditor5-ui/components/tooltip/tooltip.css
@@ -12,6 +12,12 @@
 .ck.ck-tooltip {
 	left: 50%;
 
+	/*
+	 * Prevent blurry tooltips in LoDPI environments.
+	 * See https://github.com/ckeditor/ckeditor5/issues/1802.
+	 */
+	top: 0;
+
 	/**
 	 * A class once applied displays the tooltip south of the element.
 	 *


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Tooltips should not render blurry in LoDPI environments. Closes ckeditor/ckeditor5#1802.
