### PR TITLE
i/5793: Moved restricted-editing package styles to theme-lark

### DIFF
--- a/theme/ckeditor5-restricted-editing/restrictedediting.css
+++ b/theme/ckeditor5-restricted-editing/restrictedediting.css
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+:root {
+	--ck-color-restricted-editing-exception-background: hsla(31, 100%, 65%, .2);
+	--ck-color-restricted-editing-exception-brackets: hsla(31, 100%, 40%, .4);
+	--ck-color-restricted-editing-selected-exception-background: hsla(31, 100%, 65%, .5);
+	--ck-color-restricted-editing-selected-exception-brackets: hsla(31, 100%, 40%, .6);
+}
+
+.ck-editor__editable .ck-restricted-editing-exception {
+	transition: .2s ease-in-out background;
+	background-color: var(--ck-color-restricted-editing-exception-background);
+	border: 1px solid;
+	border-image: linear-gradient(
+		to right,
+		var(--ck-color-restricted-editing-exception-brackets) 0%,
+		var(--ck-color-restricted-editing-exception-brackets) 5px,
+		hsla(0, 0%, 0%, 0) 6px,
+		hsla(0, 0%, 0%, 0) calc(100% - 6px),
+		var(--ck-color-restricted-editing-exception-brackets) calc(100% - 5px),
+		var(--ck-color-restricted-editing-exception-brackets) 100%
+	) 1;
+
+	&.ck-restricted-editing-exception_selected {
+		background-color: var(--ck-color-restricted-editing-selected-exception-background);
+		border-image: linear-gradient(
+			to right,
+			var(--ck-color-restricted-editing-selected-exception-brackets) 0%,
+			var(--ck-color-restricted-editing-selected-exception-brackets) 5px,
+			var(--ck-color-restricted-editing-selected-exception-brackets) calc(100% - 5px),
+			var(--ck-color-restricted-editing-selected-exception-brackets) 100%
+		) 1;
+	}
+
+	&.ck-restricted-editing-exception_collapsed {
+		padding-left: 1em;
+	}
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Moved restricted-editing package styles to theme-lark. Closes ckeditor/ckeditor5#5793.

---

### Additional information

Part of https://github.com/ckeditor/ckeditor5-restricted-editing/pull/4.
