### PR TITLE
i/5992: Set default cursor in restricted editing mode

### DIFF
--- a/theme/ckeditor5-restricted-editing/restrictedediting.css
+++ b/theme/ckeditor5-restricted-editing/restrictedediting.css
@@ -39,3 +39,19 @@
 		padding-left: 1em;
 	}
 }
+
+.ck-restricted-editing_mode_restricted {
+	cursor: default;
+
+	& *:not(.restricted-editing-exception) {
+		cursor: default;
+	}
+}
+
+.ck-restricted-editing_mode_restricted .restricted-editing-exception {
+	cursor: text;
+
+	& * {
+		cursor: text;
+	}
+}

--- a/theme/ckeditor5-restricted-editing/restrictedediting.css
+++ b/theme/ckeditor5-restricted-editing/restrictedediting.css
@@ -43,6 +43,7 @@
 .ck-restricted-editing_mode_restricted {
 	cursor: default;
 
+	/* For some reason, we also need to override user agent styles for links inside the editor. */
 	& *:not(.restricted-editing-exception) {
 		cursor: default;
 	}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Set default cursor in restricted editing mode while restricted editing exceptions still have text cursor when you hover over them. Closes ckeditor/ckeditor5#5992.
