### PR TITLE
i/6272: Fix styles for restricted editing cursor behaviour

### DIFF
--- a/theme/ckeditor5-restricted-editing/restrictedediting.css
+++ b/theme/ckeditor5-restricted-editing/restrictedediting.css
@@ -42,23 +42,24 @@
 	}
 }
 
-.ck-restricted-editing_mode_restricted .restricted-editing-exception {
-	cursor: text;
-
-	& * {
-		cursor: text;
-	}
-
-	&:hover {
-		background: var(--ck-color-restricted-editing-exception-hover-background);
-	}
-}
-
 .ck-restricted-editing_mode_restricted {
 	cursor: default;
 
-	/* For some reason, we also need to override user agent styles for links inside the editor. */
-	& *:not(.restricted-editing-exception) {
+	/* We also have to override all elements inside the restricted editable to prevent cursor switching between default and text
+	during the pointer movement. */
+	& * {
 		cursor: default;
+	}
+
+	& .restricted-editing-exception {
+		cursor: text;
+
+		& * {
+			cursor: text;
+		}
+
+		&:hover {
+			background: var(--ck-color-restricted-editing-exception-hover-background);
+		}
 	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Pointer inside the restricted editing exception should be set to `text` for all children. Closes ckeditor/ckeditor5#6272.

---

### Additional information

Pointer for all of the elements inside the restricted editing mode should be set to `default` except for restricted editing exceptions and their children, where it should be set to `text`.

The fix also contains code refactoring for the styles.
