### PR TITLE
i/6507: Clean up the form header styling

### DIFF
--- a/theme/ckeditor5-ui/components/formheader/formheader.css
+++ b/theme/ckeditor5-ui/components/formheader/formheader.css
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+:root {
+	--ck-table-form-header-height: 38px;
+}
+
+.ck.ck-form__header {
+	padding: var(--ck-spacing-small) var(--ck-spacing-large);
+	height: var(--ck-table-form-header-height);
+	line-height: var(--ck-table-form-header-height);
+	border-bottom: 1px solid var(--ck-color-base-border);
+
+	& .ck-form__header__label {
+		font-weight: bold;
+	}
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Moved part of the form header component styling to the theme-lark. See ckeditor/ckeditor5#6507.

-- 
Master PR: https://github.com/ckeditor/ckeditor5-ui/pull/550

