### PR TITLE
I/6586: Add missing form header styles and remove duplicated styling for special characters

### DIFF
--- a/theme/ckeditor5-special-characters/specialcharacters.css
+++ b/theme/ckeditor5-special-characters/specialcharacters.css
@@ -6,16 +6,6 @@
 @import "@ckeditor/ckeditor5-ui/theme/mixins/_dir.css";
 
 .ck.ck-special-characters-navigation {
-	border-bottom: 1px solid var(--ck-color-base-border);
-	padding: var(--ck-spacing-standard) var(--ck-spacing-large);
-
-	@mixin ck-dir ltr {
-		padding-left: var(--ck-spacing-large);
-	}
-
-	@mixin ck-dir rtl {
-		padding-right: var(--ck-spacing-large);
-	}
 
 	& > .ck-label {
 		max-width: 160px;

--- a/theme/ckeditor5-ui/components/formheader/formheader.css
+++ b/theme/ckeditor5-ui/components/formheader/formheader.css
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+:root {
+	--ck-table-form-header-height: 38px;
+}
+
+.ck.ck-form__header {
+	padding: var(--ck-spacing-small) var(--ck-spacing-large);
+	height: var(--ck-table-form-header-height);
+	line-height: var(--ck-table-form-header-height);
+	border-bottom: 1px solid var(--ck-color-base-border);
+
+	& .ck-form__header__label {
+		font-weight: bold;
+	}
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Added missing file for `FormHeader` styling and removed duplicated styling for `SpecialCharactersNavigation` inherited from `FormHeader` component. Closes ckeditor/ckeditor5#6586.