### PR TITLE
i/6446: Fix the table selection background

### DIFF
--- a/theme/ckeditor5-table/tableselection.css
+++ b/theme/ckeditor5-table/tableselection.css
@@ -4,19 +4,29 @@
  */
 
 :root {
-	--ck-table-selected-cell-background: hsl(210, 92%, 90%);
+	--ck-table-selected-cell-background: hsla(208, 90%, 80%, .3);
 }
 
 .ck.ck-editor__editable .table table {
 	& td.ck-editor__editable_selected,
 	& th.ck-editor__editable_selected {
-		background-color: var(--ck-table-selected-cell-background) !important;
-
+		position: relative;
 		caret-color: transparent;
 		outline: unset;
 		box-shadow: unset;
 
-		& ::selection {
+		&:after {
+			content: '';
+			background-color: var(--ck-table-selected-cell-background);
+			position: absolute;
+    	top: 0;
+    	left: 0;
+    	right: 0;
+    	bottom: 0;
+		}
+
+		& ::selection,
+		&:focus {
 			background-color: transparent;
 		}
 
@@ -25,4 +35,3 @@
 		}
 	}
 }
-

--- a/theme/ckeditor5-table/tableselection.css
+++ b/theme/ckeditor5-table/tableselection.css
@@ -4,7 +4,7 @@
  */
 
 :root {
-		--ck-table-selected-cell-background: hsla(208, 90%, 80%, .3);
+	--ck-table-selected-cell-background: hsla(208, 90%, 80%, .3);
 }
 
 .ck.ck-editor__editable .table table {
@@ -17,6 +17,7 @@
 
 		&:after {
 			content: '';
+			pointer-events: none;
 			background-color: var(--ck-table-selected-cell-background);
 			position: absolute;
 			top: 0;

--- a/theme/ckeditor5-table/tableselection.css
+++ b/theme/ckeditor5-table/tableselection.css
@@ -4,7 +4,7 @@
  */
 
 :root {
-	--ck-table-selected-cell-background: hsla(208, 90%, 80%, .3);
+		--ck-table-selected-cell-background: hsla(208, 90%, 80%, .3);
 }
 
 .ck.ck-editor__editable .table table {
@@ -19,10 +19,10 @@
 			content: '';
 			background-color: var(--ck-table-selected-cell-background);
 			position: absolute;
-    	top: 0;
-    	left: 0;
-    	right: 0;
-    	bottom: 0;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
 		}
 
 		& ::selection,

--- a/theme/ckeditor5-table/tableselection.css
+++ b/theme/ckeditor5-table/tableselection.css
@@ -15,6 +15,7 @@
 		outline: unset;
 		box-shadow: unset;
 
+		/* https://github.com/ckeditor/ckeditor5/issues/6446 */
 		&:after {
 			content: '';
 			pointer-events: none;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Improved table cell background in multi selection. Closes ckeditor/ckeditor5#6446.

---

### Additional information

- From now on, user is able to see table cell background changes in the live preview.
